### PR TITLE
Exception if the url addresses a server at a subpath

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var existResponse = {
 
 module.exports = function configure (url, callback) {
   var db = nanoOption(url)
-  var couch = nanoOption(db.config.url)
+  var couch = nanoOption({url: db.config.url, parseUrl: false})
 
   couch.request({
     method: 'HEAD',

--- a/test.js
+++ b/test.js
@@ -36,3 +36,11 @@ test('url is nano object', function (t) {
     t.end()
   })
 })
+
+test('does not throw for server at subpath', function (t) {
+  t.doesNotThrow(function () {
+    ensure('http://example.com/couchdb/database', function () {
+      t.end()
+    })
+  }, 'did throw an exception')
+})


### PR DESCRIPTION
if you try to ensure a db exists in the server http://localhost/couchserver/ with the url http://localhost/couchserver/database/ an error is thrown.

I tried to include a test, but I have no idea how the actually test the function without requiring an complicated external setup of a couchdb server at a subpath. So I just included a test to ensure no exception is raised.